### PR TITLE
[STEP11] 6주차 기본과제 제출

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
 	// redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+	// redisson
+	implementation("org.redisson:redisson-spring-boot-starter:3.46.0")
+
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
+	// redis
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 	// swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    container_name: concert-redis
+    image: redis
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"] # 레디스 영속성 설정
+    volumes:
+      - ./data/redis/:/data
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/service/balance/BalanceService.java
+++ b/src/main/java/kr/hhplus/be/server/service/balance/BalanceService.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.service.balance;
 
 import static kr.hhplus.be.server.support.exception.BusinessError.*;
+import static kr.hhplus.be.server.support.lock.LockType.*;
 
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import jakarta.persistence.OptimisticLockException;
 import kr.hhplus.be.server.domain.balance.Balance;
 import kr.hhplus.be.server.domain.balance.BalanceRepository;
 import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -33,6 +35,7 @@ public class BalanceService {
 	}
 
 	@Transactional
+	@DistributedLock(key = "'userId:' + #command.getUserId()", leaseTime = 2, type = SIMPLE)
 	public BalanceInfo charge(BalanceCommand.Charge command) {
 		try {
 			userRepository.findById(command.getUserId())

--- a/src/main/java/kr/hhplus/be/server/service/payment/PaymentService.java
+++ b/src/main/java/kr/hhplus/be/server/service/payment/PaymentService.java
@@ -1,8 +1,7 @@
 package kr.hhplus.be.server.service.payment;
 
 import static kr.hhplus.be.server.support.exception.BusinessError.*;
-
-import java.time.LocalDateTime;
+import static kr.hhplus.be.server.support.lock.LockType.*;
 
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -18,6 +17,7 @@ import kr.hhplus.be.server.domain.reservation.ReservationRepository;
 import kr.hhplus.be.server.domain.token.TokenRepository;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -31,6 +31,7 @@ public class PaymentService {
 	private final ReservationRepository reservationRepository;
 
 	@Transactional
+	@DistributedLock(key = "'userId:' + #command.getUserId()", leaseTime = 2, type = SIMPLE)
 	public PaymentInfo pay(PaymentCommand command) {
 
 		try {

--- a/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
@@ -18,7 +18,7 @@ import kr.hhplus.be.server.domain.reservation.ReservationRepository;
 import kr.hhplus.be.server.domain.reservation.ReservationStatus;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserRepository;
-import kr.hhplus.be.server.support.exception.BusinessError;
+import kr.hhplus.be.server.support.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -30,8 +30,8 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 
 	@Transactional
+	@DistributedLock(key = "'seatId:' + #command.getSeatId()")
 	public ReservationInfo reserve(ReservationCommand command) {
-
 		try {
 			User user = userRepository.findById(command.getUserId())
 				.orElseThrow(NOT_FOUND_USER_ERROR::exception);

--- a/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
@@ -31,7 +31,7 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 
 	@Transactional
-	@DistributedLock(key = "'seatId:' + #command.getSeatId()", waitTime = 1, type = SPIN)
+	@DistributedLock(key = "'seatId:' + #command.getSeatId()", waitTime = 1, type = PUBSUB)
 	public ReservationInfo reserve(ReservationCommand command) {
 		try {
 			User user = userRepository.findById(command.getUserId())

--- a/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/service/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.service.reservation;
 
 import static kr.hhplus.be.server.support.exception.BusinessError.*;
+import static kr.hhplus.be.server.support.lock.LockType.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,7 +31,7 @@ public class ReservationService {
 	private final ReservationRepository reservationRepository;
 
 	@Transactional
-	@DistributedLock(key = "'seatId:' + #command.getSeatId()")
+	@DistributedLock(key = "'seatId:' + #command.getSeatId()", waitTime = 1, type = SPIN)
 	public ReservationInfo reserve(ReservationCommand command) {
 		try {
 			User user = userRepository.findById(command.getUserId())

--- a/src/main/java/kr/hhplus/be/server/support/config/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.support.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public LettuceConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+		return new StringRedisTemplate(connectionFactory);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/config/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/support/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.support.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	private static final String REDISSON_HOST_PREFIX = "redis://";
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/exception/BusinessError.java
+++ b/src/main/java/kr/hhplus/be/server/support/exception/BusinessError.java
@@ -40,7 +40,10 @@ public enum BusinessError {
 
 	// 토큰 관련
 	NOT_FOUND_TOKEN_ERROR(BAD_REQUEST, "토큰값을 찾을 수 없습니다."),
-	TOKEN_NOT_ACTIVE_ERROR(BAD_REQUEST, "토큰이 ACTIVE 상태가 아니므로 사용할 수 없습니다.");
+	TOKEN_NOT_ACTIVE_ERROR(BAD_REQUEST, "토큰이 ACTIVE 상태가 아니므로 사용할 수 없습니다."),
+
+	// 락 관련
+	LOCK_ACQUISITION_FAILED_ERROR(BAD_REQUEST, "락 획득에 실패했습니다.");
 
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/kr/hhplus/be/server/support/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/DistributedLock.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.support.lock;
+
+import static kr.hhplus.be.server.support.lock.LockType.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+	String key();
+	LockType type() default SIMPLE;
+	long waitTime() default 5;
+	long leaseTime() default 5;
+	TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/DistributedLockAspect.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/DistributedLockAspect.java
@@ -1,5 +1,7 @@
 package kr.hhplus.be.server.support.lock;
 
+import static kr.hhplus.be.server.support.exception.BusinessError.*;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.UUID;
@@ -49,7 +51,7 @@ public class DistributedLockAspect {
 		boolean lockSuccess = strategy.tryLock(lockKey, value, waitTime, leaseTime, timeUnit);
 
 		if (!lockSuccess) {
-			throw new IllegalArgumentException("락 획득에 실패했습니다.");
+			throw LOCK_ACQUISITION_FAILED_ERROR.exception();
 		}
 
 		try {

--- a/src/main/java/kr/hhplus/be/server/support/lock/DistributedLockAspect.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/DistributedLockAspect.java
@@ -1,0 +1,76 @@
+package kr.hhplus.be.server.support.lock;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import kr.hhplus.be.server.support.lock.strategy.LockStrategy;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class DistributedLockAspect {
+
+	private static final String LOCK_PREFIX = "lock:";
+
+	private final LockStrategyFactory lockStrategyFactory;
+
+	@Around("@annotation(kr.hhplus.be.server.support.lock.DistributedLock)")
+	public Object acquireLock(ProceedingJoinPoint joinPoint) throws Throwable {
+
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		Method method = signature.getMethod();
+		Object[] args = joinPoint.getArgs();
+
+		DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+		String lockKey = lockKeyParser(distributedLock.key(), method, args);
+		String value = UUID.randomUUID().toString();
+		LockStrategy strategy = lockStrategyFactory.getStrategy(distributedLock.type());
+
+		long waitTime = distributedLock.waitTime();
+		long leaseTime = distributedLock.leaseTime();
+		TimeUnit timeUnit = distributedLock.timeUnit();
+
+		boolean lockSuccess = strategy.tryLock(lockKey, value, waitTime, leaseTime, timeUnit);
+
+		if (!lockSuccess) {
+			throw new IllegalArgumentException("락 획득에 실패했습니다.");
+		}
+
+		try {
+			return joinPoint.proceed();
+		} finally {
+			strategy.unLock(lockKey, value);
+		}
+	}
+
+	private String lockKeyParser(String lockKey, Method method, Object[] args) {
+
+		ExpressionParser parser = new SpelExpressionParser();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+
+		Parameter[] parameters = method.getParameters();
+
+		for (int i = 0; i < parameters.length; i++) {
+			context.setVariable(parameters[i].getName(), args[i]);
+		}
+
+		Expression expression = parser.parseExpression(lockKey);
+		return LOCK_PREFIX + expression.getValue(context, String.class);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 import kr.hhplus.be.server.support.lock.strategy.LockStrategy;
+import kr.hhplus.be.server.support.lock.strategy.PubSubLockStrategy;
 import kr.hhplus.be.server.support.lock.strategy.SimpleLockStrategy;
 import kr.hhplus.be.server.support.lock.strategy.SpinLockStrategy;
 
@@ -15,10 +16,11 @@ public class LockStrategyFactory {
 
 	private final Map<LockType, LockStrategy> strategies;
 
-	public LockStrategyFactory(SimpleLockStrategy simple, SpinLockStrategy spin) {
+	public LockStrategyFactory(SimpleLockStrategy simple, SpinLockStrategy spin, PubSubLockStrategy pubSub) {
 		this.strategies = Map.of(
 			SIMPLE, simple,
-			SPIN, spin
+			SPIN, spin,
+			PUBSUB, pubSub
 		);
 	}
 

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
@@ -1,20 +1,24 @@
 package kr.hhplus.be.server.support.lock;
 
+import static kr.hhplus.be.server.support.lock.LockType.*;
+
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
 import kr.hhplus.be.server.support.lock.strategy.LockStrategy;
 import kr.hhplus.be.server.support.lock.strategy.SimpleLockStrategy;
+import kr.hhplus.be.server.support.lock.strategy.SpinLockStrategy;
 
 @Component
 public class LockStrategyFactory {
 
 	private final Map<LockType, LockStrategy> strategies;
 
-	public LockStrategyFactory(SimpleLockStrategy simple) {
+	public LockStrategyFactory(SimpleLockStrategy simple, SpinLockStrategy spin) {
 		this.strategies = Map.of(
-			LockType.SIMPLE, simple
+			SIMPLE, simple,
+			SPIN, spin
 		);
 	}
 

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockStrategyFactory.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.support.lock;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import kr.hhplus.be.server.support.lock.strategy.LockStrategy;
+import kr.hhplus.be.server.support.lock.strategy.SimpleLockStrategy;
+
+@Component
+public class LockStrategyFactory {
+
+	private final Map<LockType, LockStrategy> strategies;
+
+	public LockStrategyFactory(SimpleLockStrategy simple) {
+		this.strategies = Map.of(
+			LockType.SIMPLE, simple
+		);
+	}
+
+	public LockStrategy getStrategy(LockType lockType) {
+		return strategies.get(lockType);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
@@ -1,5 +1,5 @@
 package kr.hhplus.be.server.support.lock;
 
 public enum LockType {
-	SPIN, SIMPLE
+	SPIN, SIMPLE, PUBSUB
 }

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.support.lock;
+
+public enum LockType {
+	SIMPLE
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/LockType.java
@@ -1,5 +1,5 @@
 package kr.hhplus.be.server.support.lock;
 
 public enum LockType {
-	SIMPLE
+	SPIN, SIMPLE
 }

--- a/src/main/java/kr/hhplus/be/server/support/lock/strategy/LockStrategy.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/strategy/LockStrategy.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import java.util.concurrent.TimeUnit;
+
+public interface LockStrategy {
+	boolean tryLock(String key, String value, long waitTime, long leaseTime, TimeUnit timeUnit);
+	void unLock(String key, String value);
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategy.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategy.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PubSubLockStrategy implements LockStrategy {
+
+	private final RedissonClient redissonClient;
+
+	@Override
+	public boolean tryLock(String key, String value, long waitTime, long leaseTime, TimeUnit timeUnit) {
+		RLock lock = redissonClient.getLock(key);
+		try {
+			return lock.tryLock(waitTime, leaseTime, timeUnit);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	@Override
+	public void unLock(String key, String value) {
+		RLock lock = redissonClient.getLock(key);
+		if (lock.isHeldByCurrentThread()) {
+			lock.unlock();
+		}
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategy.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategy.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SimpleLockStrategy implements LockStrategy {
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	@Override
+	public boolean tryLock(String key, String value, long waitTime, long leaseTime, TimeUnit timeUnit) {
+		return Boolean.TRUE.equals(
+			stringRedisTemplate.opsForValue()
+				.setIfAbsent(key, value, leaseTime, timeUnit));
+	}
+
+	@Override
+	public void unLock(String key, String value) {
+		String script = """
+			if redis.call('get', KEYS[1]) == ARGV[1] then
+				return redis.call('del', KEYS[1])
+			else
+				return 0
+			end
+		""";
+		stringRedisTemplate.execute(RedisScript.of(script, Long.class), List.of(key), value);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategy.java
+++ b/src/main/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategy.java
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SpinLockStrategy implements LockStrategy {
+
+	private static final int RETRY_INTERVAL_MS = 100;
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	@Override
+	public boolean tryLock(String key, String value, long waitTime, long leaseTime, TimeUnit timeUnit) {
+
+		long waitTimeInMillis = timeUnit.toMillis(waitTime);
+		long end = System.currentTimeMillis() + waitTimeInMillis;
+
+		while (System.currentTimeMillis() < end) {
+			Boolean success = stringRedisTemplate.opsForValue()
+				.setIfAbsent(key, value, leaseTime, timeUnit);
+
+			if (Boolean.TRUE.equals(success)) {
+				return true;
+			}
+
+			try {
+				Thread.sleep(RETRY_INTERVAL_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public void unLock(String key, String value) {
+		String script = """
+			if redis.call('get', KEYS[1]) == ARGV[1] then
+				return redis.call('del', KEYS[1])
+			else
+				return 0
+			end
+		""";
+		stringRedisTemplate.execute(RedisScript.of(script, Long.class), List.of(key), value);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,11 +16,14 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
-
+  data:
+    redis:
+      port: 6379
+      host: localhost
 ---
 spring.config.activate.on-profile: local, test
 

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -5,13 +5,17 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -23,12 +27,22 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis"))
+			.withExposedPorts(6379);
+		REDIS_CONTAINER.start();
+
+		System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
+		System.setProperty("spring.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/interfaces/concert/ConcertRequestTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/concert/ConcertRequestTest.java
@@ -17,7 +17,9 @@ class ConcertRequestTest {
 	@Test
 	@DisplayName("정상적인 연월을 입력하면 ConcertCommand.Schedule이 생성된다")
 	void toCommand_성공() {
-		ConcertRequest.ConcertSchedule request = new ConcertRequest.ConcertSchedule("2025-04");
+
+		String yearMonth = YearMonth.now().toString();
+		ConcertRequest.ConcertSchedule request = new ConcertRequest.ConcertSchedule(yearMonth);
 
 		ConcertCommand.Schedule command = request.toCommand(1L);
 		assertThat(command.getConcertId()).isEqualTo(1L);

--- a/src/test/java/kr/hhplus/be/server/support/lock/DistributedLockAspectTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/DistributedLockAspectTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.support.lock;
+
+import kr.hhplus.be.server.support.exception.BusinessException;
+import kr.hhplus.be.server.support.lock.strategy.LockStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DistributedLockAspectTest {
+
+	private LockStrategyFactory lockStrategyFactory;
+	private LockStrategy lockStrategy;
+	private DistributedService distributedService;
+
+	@BeforeEach
+	void setUp() {
+		lockStrategyFactory = mock(LockStrategyFactory.class);
+		lockStrategy = mock(LockStrategy.class);
+		when(lockStrategyFactory.getStrategy(any())).thenReturn(lockStrategy);
+
+		DistributedLockAspect aspect = new DistributedLockAspect(lockStrategyFactory);
+
+		AspectJProxyFactory factory = new AspectJProxyFactory(new DistributedService());
+		factory.addAspect(aspect);
+		distributedService = factory.getProxy();
+	}
+
+	@Test
+	@DisplayName("락 획득에 성공하면 비즈니스로직이 정상적으로 실행되고 락이 해제된다")
+	void success() {
+		// arrange
+		when(lockStrategy.tryLock(anyString(), anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+			.thenReturn(true);
+
+		// act
+		String result = distributedService.lock("abc");
+
+		// assert
+		assertThat(result).isEqualTo("success");
+		verify(lockStrategy).unLock(startsWith("lock:"), anyString());
+	}
+
+	@Test
+	@DisplayName("락 획득에 실패하면 예외가 발생하고 이후 로직은 실행되지 않는다.")
+	void fail_lock() {
+		// arrange
+		when(lockStrategy.tryLock(anyString(), anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+			.thenReturn(false);
+
+		// act & assert
+		assertThatThrownBy(() -> distributedService.lock("abc"))
+			.isInstanceOf(BusinessException.class)
+			.hasMessageContaining("락 획득에 실패했습니다.");
+
+		verify(lockStrategy, never()).unLock(anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("락을 획득하고 비즈니스 로직 실행시 예외가 발생하면 락은 해제된다.")
+	void fail_business() {
+		// arrange
+		when(lockStrategy.tryLock(anyString(), anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+			.thenReturn(true);
+
+		// act & assert
+		assertThatThrownBy(() -> distributedService.lockException("abc"))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("비즈니스 실패");
+
+		verify(lockStrategy).unLock(startsWith("lock:"), anyString());
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/DistributedService.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/DistributedService.java
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.support.lock;
+
+public class DistributedService {
+	@DistributedLock(key = "#id", leaseTime = 2)
+	public String lock(String id) {
+		return "success";
+	}
+
+	@DistributedLock(key = "#id", leaseTime = 2)
+	public String lockException(String id) {
+		throw new RuntimeException("비즈니스 실패");
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategyIntegrateTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategyIntegrateTest.java
@@ -1,0 +1,93 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PubSubLockStrategyIntegrateTest {
+
+	@Autowired
+	private PubSubLockStrategy pubSubLockStrategy;
+
+	@Autowired
+	private RedissonClient redissonClient;
+
+	private final String key = "lock:test";
+
+	@AfterEach
+	void tearDown() {
+		redissonClient.getKeys().delete(key);
+	}
+
+	@Test
+	@DisplayName("락을 획득할 수 있다")
+	void tryLock_success() {
+		// arrange
+		String value = "unique-value";
+
+		// act
+		boolean result = pubSubLockStrategy.tryLock(key, value, 3, 5, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("다른 스레드가 이미 락을 잡고 있으면 락 획득에 실패한다")
+	void tryLock_fails() throws InterruptedException {
+		// arrange
+		String value1 = "unique-value";
+		String value2 = "unique-value";
+
+		// 먼저 락을 잡고 있는 스레드
+		Thread lockerThread = new Thread(() -> {
+			pubSubLockStrategy.tryLock(key, value1, 1, 5, TimeUnit.SECONDS);
+			try {
+				Thread.sleep(2000); // 2초 동안 락 유지
+			} catch (InterruptedException ignored) {}
+		});
+		lockerThread.start();
+		Thread.sleep(500); // 락이 먼저 잡히도록 대기
+
+		// 락 획득 시도 결과 저장용
+		AtomicBoolean result = new AtomicBoolean(true);
+
+		// 락을 획득하려는 다른 스레드
+		Thread otherThread = new Thread(() -> {
+			boolean success = pubSubLockStrategy.tryLock(key, value2, 1, 1, TimeUnit.SECONDS);
+			result.set(success); // 기대값: false
+		});
+
+		// act
+		otherThread.start();
+		otherThread.join(); // 결과 기다림
+		lockerThread.join();
+
+		// assert
+		assertThat(result.get()).isFalse();
+	}
+
+	@Test
+	@DisplayName("락을 해제하면 잠금이 풀린다")
+	void unlock_success() {
+		// arrange
+		pubSubLockStrategy.tryLock(key, "val", 1, 10, TimeUnit.SECONDS);
+
+		// act
+		pubSubLockStrategy.unLock(key, "val");
+
+		// assert
+		boolean available = redissonClient.getLock(key).tryLock();
+		assertThat(available).isTrue();
+		redissonClient.getLock(key).unlock(); // 정리
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategyUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/PubSubLockStrategyUnitTest.java
@@ -1,0 +1,86 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+@ExtendWith(MockitoExtension.class)
+class PubSubLockStrategyUnitTest {
+
+	@Mock
+	private RLock rLock;
+
+	@Mock
+	private RedissonClient redissonClient;
+
+	@InjectMocks
+	private PubSubLockStrategy pubSubLockStrategy;
+
+	@Test
+	@DisplayName("tryLock 성공 시 true 반환")
+	void tryLock_success() throws InterruptedException {
+		// arrange
+		when(redissonClient.getLock("key")).thenReturn(rLock);
+		when(rLock.tryLock(3, 5, TimeUnit.SECONDS)).thenReturn(true);
+
+		// act
+		boolean result = pubSubLockStrategy.tryLock("key", "value", 3, 5, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isTrue();
+		verify(rLock).tryLock(3, 5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	@DisplayName("tryLock 인터럽트 발생 시 false 반환")
+	void tryLock_interrupted() throws InterruptedException {
+		// arrange
+		when(redissonClient.getLock("key")).thenReturn(rLock);
+		when(rLock.tryLock(3, 5, TimeUnit.SECONDS)).thenThrow(new InterruptedException());
+
+		// act
+		boolean result = pubSubLockStrategy.tryLock("key", "value", 3, 5, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isFalse();
+		verify(rLock).tryLock(3, 5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	@DisplayName("현재 스레드가 락을 가지고 있으면 unlock 수행")
+	void unLock_success() {
+		// arrange
+		when(redissonClient.getLock("key")).thenReturn(rLock);
+		when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+		// act
+		pubSubLockStrategy.unLock("key", "value");
+
+		// assert
+		verify(rLock).unlock();
+	}
+
+	@Test
+	@DisplayName("현재 스레드가 락을 가지고 있지 않으면 unlock 하지 않음")
+	void unLock_notHeldByCurrentThread() {
+		// arrange
+		when(redissonClient.getLock("key")).thenReturn(rLock);
+		when(rLock.isHeldByCurrentThread()).thenReturn(false);
+
+		// act
+		pubSubLockStrategy.unLock("key", "value");
+
+		// assert
+		verify(rLock, never()).unlock();
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategyIntegrateTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategyIntegrateTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+class SimpleLockStrategyIntegrateTest {
+
+	@AfterEach
+	void tearDown() {
+		stringRedisTemplate.delete("lock");
+	}
+
+	@Autowired
+	private StringRedisTemplate stringRedisTemplate;
+
+	@Autowired
+	private SimpleLockStrategy simpleLockStrategy;
+
+	@Test
+	@DisplayName("tryLock 메서드로 락을 잡을 수 있다.")
+	void try_lock() {
+		// arrange
+		String key = "lock";
+		String value = "test";
+		long waitTime = 5;
+		long leaseTime = 300;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+		// act
+		boolean success = simpleLockStrategy.tryLock(key, value, waitTime, leaseTime, timeUnit);
+		// assert
+		String saveLock = stringRedisTemplate.opsForValue().get(key);
+		assertThat(success).isTrue();
+		assertThat(saveLock).isEqualTo(value);
+	}
+
+	@Test
+	@DisplayName("락을 잡고있는동안에는 락을 획득할 수 없다.")
+	void try_lock_fail() {
+		// arrange
+		String key = "lock";
+		String value = "test";
+		long waitTime = 5;
+		long leaseTime = 300;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+		stringRedisTemplate.opsForValue().setIfAbsent(key, value, leaseTime, timeUnit);
+
+		// act
+		boolean success = simpleLockStrategy.tryLock(key, value, waitTime, leaseTime, timeUnit);
+		// assert
+		assertThat(success).isFalse();
+	}
+
+	@Test
+	@DisplayName("락을 해제할 수 있다.")
+	void un_lock() {
+		// arrange
+		String key = "lock";
+		String value = "test";
+		long leaseTime = 300;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+		stringRedisTemplate.opsForValue().setIfAbsent(key, value, leaseTime, timeUnit);
+		// act
+		simpleLockStrategy.unLock(key, value);
+		// assert
+		String result = stringRedisTemplate.opsForValue().get(key);
+		assertThat(result).isEqualTo(null);
+	}
+
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategyUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/SimpleLockStrategyUnitTest.java
@@ -1,0 +1,83 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+class SimpleLockStrategyUnitTest {
+
+	@Mock
+	private StringRedisTemplate stringRedisTemplate;
+
+	@InjectMocks
+	private SimpleLockStrategy simpleLockStrategy;
+
+	@Test
+	@DisplayName("락을 획득할 수 있으면 true를 반환한다.")
+	void lock_success() {
+		// arrange
+		long waitTime = 5;
+		long leaseTime = 5;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+
+		ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent("lock:1", "value", leaseTime, timeUnit)).thenReturn(true);
+
+		// act & assert
+		boolean success = simpleLockStrategy.tryLock("lock:1", "value", waitTime, leaseTime, timeUnit);
+
+		// assert
+		assertThat(success).isTrue();
+	}
+
+	@Test
+	@DisplayName("락을 획득하지 못하면 false를 반환한다.")
+	void lock_fail() {
+		// arrange
+		long waitTime = 5;
+		long leaseTime = 5;
+		TimeUnit timeUnit = TimeUnit.SECONDS;
+
+		ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent("lock:1", "value", leaseTime, timeUnit)).thenReturn(false);
+
+		// act & assert
+		boolean success = simpleLockStrategy.tryLock("lock:1", "value", waitTime, leaseTime, timeUnit);
+
+		// assert
+		assertThat(success).isFalse();
+	}
+
+	@Test
+	@DisplayName("unlock 시 Lua 스크립트가 실행된다")
+	void unlock_executes_lua_script() {
+		// arrange
+		String key = "lock:1";
+		String value = "value";
+
+		// act
+		simpleLockStrategy.unLock(key, value);
+
+		// assert
+		verify(stringRedisTemplate).execute(
+			any(RedisScript.class),
+			eq(List.of(key)),
+			eq(value)
+		);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategyIntegrateTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategyIntegrateTest.java
@@ -1,0 +1,72 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+class SpinLockStrategyIntegrateTest {
+
+	@Autowired
+	private SpinLockStrategy spinLockStrategy;
+
+	@Autowired
+	private StringRedisTemplate stringRedisTemplate;
+
+	@AfterEach
+	void tearDown() {
+		stringRedisTemplate.delete("lock:test");
+	}
+
+	@Test
+	@DisplayName("락을 잡을 수 있으면 true 반환")
+	void tryLock_success() {
+		// arrange
+		String key = "lock:test";
+		String value = "test-value";
+		// act
+		boolean result = spinLockStrategy.tryLock(key, value, 3, 3, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isTrue();
+		assertThat(stringRedisTemplate.opsForValue().get(key)).isEqualTo(value);
+	}
+
+	@Test
+	@DisplayName("이미 락이 잡혀 있으면 재시도 끝에 false 반환")
+	void tryLock_fail_due_to_existing_lock() {
+		// arrange
+		String key = "lock:test";
+		String value = "test-value";
+		stringRedisTemplate.opsForValue().setIfAbsent(key, "someone-else", 10, TimeUnit.SECONDS);
+
+		// act
+		boolean result = spinLockStrategy.tryLock(key, value, 3, 3, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isFalse();
+		assertThat(stringRedisTemplate.opsForValue().get(key)).isEqualTo("someone-else");
+	}
+
+	@Test
+	@DisplayName("락을 해제하면 Redis에서 키가 사라진다")
+	void unlock_success() {
+		// arrange
+		String key = "lock:test";
+		String value = "test-value";
+		stringRedisTemplate.opsForValue().set(key, value);
+
+		// act
+		spinLockStrategy.unLock(key, value);
+
+		// assert
+		assertThat(stringRedisTemplate.opsForValue().get(key)).isNull();
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategyUnitTest.java
+++ b/src/test/java/kr/hhplus/be/server/support/lock/strategy/SpinLockStrategyUnitTest.java
@@ -1,0 +1,107 @@
+package kr.hhplus.be.server.support.lock.strategy;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+class SpinLockStrategyUnitTest {
+
+	@Mock
+	private StringRedisTemplate stringRedisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOps;
+
+	@InjectMocks
+	private SpinLockStrategy strategy;
+
+	@Test
+	@DisplayName("락이 바로 성공되면 true 반환")
+	void tryLock_immediate_success() {
+		// arrange
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent(anyString(), anyString(), anyLong(), any()))
+			.thenReturn(true);
+
+		// act
+		boolean result = strategy.tryLock("key", "val", 1, 1, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("락이 재시도 끝에 성공되면 true 반환")
+	void tryLock_retry_then_success() {
+		// arrange
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent(anyString(), anyString(), anyLong(), any()))
+			.thenReturn(false, false, true);
+
+		// act
+		boolean result = strategy.tryLock("key", "val", 3, 1, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("최대 재시도 실패하면 false 반환")
+	void tryLock_fail_after_retries() {
+		// arrange
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent(anyString(), anyString(), anyLong(), any()))
+			.thenReturn(false); // 3초 반복
+
+		// act
+		boolean result = strategy.tryLock("key", "val", 3, 1, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("인터럽트 발생 시 false 반환")
+	void tryLock_interrupted_exception() throws InterruptedException {
+		// arrange
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+		when(valueOps.setIfAbsent(anyString(), anyString(), anyLong(), any()))
+			.then(invocation -> {
+				Thread.currentThread().interrupt();
+				return false;
+			});
+
+		// act
+		boolean result = strategy.tryLock("key", "val", 2, 1, TimeUnit.SECONDS);
+
+		// assert
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("unlock 시 Lua 스크립트가 실행된다")
+	void unlock_should_run_script() {
+		// act
+		strategy.unLock("lockKey", "value");
+
+		// assert
+		verify(stringRedisTemplate).execute(
+			any(RedisScript.class),
+			eq(List.of("lockKey")),
+			eq("value")
+		);
+	}
+}


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- simpleLock 적용 및 테스트 작성: https://github.com/kimbro97/concert-server/commit/027d613e12ae922d699297b8e1609a3f402a1b2f https://github.com/kimbro97/concert-server/commit/2a6ca8b81e4145147268bd0eb6c2e5515a58cf9e
- spinLock 적용 및 테스트 작성: https://github.com/kimbro97/concert-server/commit/c4896f0907c078a25f4e5357ed840374ddc25bd2 https://github.com/kimbro97/concert-server/commit/5b7534375d07681d7cc5e3d5870328487720eeba
- redisson 적용 및 테스트 작성: https://github.com/kimbro97/concert-server/commit/aef8a3460d59b15f03214948d02f620c301e2262 https://github.com/kimbro97/concert-server/commit/6a1cd6363fae27824ff35169fc784963f5176528
- 분산락 AOP 테스트 작성: https://github.com/kimbro97/concert-server/commit/fbb38b2ad22873e3cf0e6289ab34d2e4303f24aa

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
  - 이번 과제에서 Redis를 활용한 분산락 AOP를 직접 구현해봤습니다.
  - 메서드에 @DistributedLock 어노테이션을 붙이면, 내부적으로 SpEL 기반으로 락 키를 생성하고,
  - 설정한 락 타입(Simple, Spin, PubSub)에 따라 전략을 선택해서 락을 적용하도록 구성했습니다.
  - 락 획득 실패 시 예외를 발생시키고, 비즈니스 로직 실행 이후엔 락을 해제하도록 처리했습니다.
  - 그리고 각각의 락 구현체는 RedisTemplate, RedissonClient 등 Redis 클라이언트에 직접 의존하고 있는데,
혹시 이런 부분도 별도의 인터페이스로 추상화해서 사용하는 게 좋을지 고민이 되었습니다.
  - 이런식으로 실무에서도 많이 사용되는건지 궁금하고 혹시 구조 측면에서 피드백 주시면 감사하겠습니다.

클래스 다이어그램

```mermaid
classDiagram
    class DistributedLock {
        <<annotation>>
        +String key
        +LockType type
        +long waitTime
        +long leaseTime
        +TimeUnit timeUnit
    }

    class DistributedLockAspect {
        +acquireLock(joinPoint)
        -lockKeyParser(key, method, args)
    }

    class LockStrategyFactory {
        -Map<LockType, LockStrategy> strategies
        +getStrategy(lockType): LockStrategy
    }

    class LockStrategy {
        <<interface>>
        +tryLock(key, value, waitTime, leaseTime, timeUnit)
        +unLock(key, value)
    }

    class SimpleLockStrategy {
        +tryLock(...)
        +unLock(...)
    }

    class SpinLockStrategy {
        +tryLock(...)
        +unLock(...)
    }

    class PubSubLockStrategy {
        +tryLock(...)
        +unLock(...)
    }

    DistributedLockAspect --> DistributedLock : @annotation
    DistributedLockAspect --> LockStrategyFactory
    LockStrategyFactory --> LockStrategy : getStrategy()
    LockStrategy <|.. SimpleLockStrategy
    LockStrategy <|.. SpinLockStrategy
    LockStrategy <|.. PubSubLockStrategy
```
- 리뷰 포인트 2
  - 포인트 충전과 결제 로직에는 SimpleLock, 좌석 예약 로직에는 PubSubLock을 적용했습니다.
  - 각 로직에 적용한 락 방식이 적절했는지, 혹은 더 나은 방식이 있을지 피드백 주시면 감사하겠습니다.
 
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->